### PR TITLE
Fix struct tag typos detected by vet

### DIFF
--- a/cmd/remotefs/main.go
+++ b/cmd/remotefs/main.go
@@ -43,7 +43,7 @@ type AzureFilesystem struct {
 	KeyBlob skr.KeyBlob `json:"key,omitempty"`
 	// This is a testing key hexstring encoded to be used against the filesystem. This should
 	// be used only for testing.
-	RawKeyHexString string `json:"raw_key, omitempty"`
+	RawKeyHexString string `json:"raw_key,omitempty"`
 }
 
 func usage() {

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -64,7 +64,7 @@ func GenerateMAAHostData(inputBytes []byte) [HOST_DATA_SIZE]byte {
 		panic(fmt.Errorf("Length of sha256 hash should be %d bytes, but it is actually %d bytes", sha256len, len(inittimeDataBytes)))
 	}
 	if sha256len > HOST_DATA_SIZE {
-		panic(fmt.Errorf("Generated hash is too large for host data. hash length: %d bytes, report host size: %d", sha256len, REPORT_DATA_SIZE))
+		panic(fmt.Errorf("Generated hash is too large for host data. hash length: %d bytes, host data size: %d", sha256len, HOST_DATA_SIZE))
 	}
 	copy(hostData[:], inittimeDataBytes)
 	return hostData

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -27,8 +27,8 @@ const (
 // Safe use of this is to ensure that the secret has enough entropy. Examples
 // include RSA private keys.
 type KeyDerivationBlob struct {
-	Salt  string `json:"salt,omitempty`
-	Label string `json:"label,omitemtpy`
+	Salt  string `json:"salt,omitempty"`
+	Label string `json:"label,omitempty"`
 }
 
 // KeyBlob contains information about the AKV service that holds the secret


### PR DESCRIPTION
## Summary
- correct JSON struct tags in `AzureFilesystem` and `KeyDerivationBlob`

## Testing
- `go vet ./...`
- `go test -run=^$ ./pkg/... ./cmd/azmount/filemanager`
